### PR TITLE
Proposal: Add double quotes for strings and deprecate single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ The syntax outline:
     * integers: `1`
     * e-notation floats: `3.1415`, `1.0e+6`
     * UTF-8 JSON-escaped strings: `строка\n线\t\u7ebf\n라인`
+      * if single quotes are used to wrap string (which is DEPRECATED),
+        additional escaping of single quotes inside string is needed:
+        `'` → `\u0027`
     * RON UUIDs `1D4ICC-XU5eRJ`, `1TUAQ+gritzko`
 2. UUIDs use a compact custom serialization
     * RON UUIDs are Base64 to save space (compare [RFC4122][rfc4122]
@@ -231,7 +234,8 @@ The syntax outline:
     * `@` starts an op's own event UUID
     * `:` starts a location UUID
     * `=` starts an integer
-    * `'` starts and ends a string
+    * `'` starts and ends a string (DEPRECATED)
+    * `"` starts and ends a string
     * `^` starts a float (e-notation)
     * `>` starts an UUID
     * `!` ends a frame header op (a reduced chunk has one header op)


### PR DESCRIPTION
Reason: simplify string encoding be removing extra single quote substitution. Single quotes induce extra complexity on encoding algorithm (extra escaping of `'` symbol).

No, it's not significantly handy to write
```
var ron = "*lww #object @time :field 'value' ;"
```
in the real client or server code. Nobody should write such code. RON is a wire format, a Swarm user doesn't write it.

(Maybe in tests somebody would write such code. But it's not what we must optimize.)